### PR TITLE
feat: add stale workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,25 @@
+name: Close stale issues and PRs
+
+on:
+  schedule:
+    - cron: "0 2 * * *"
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          days-before-stale: 30
+          days-before-close: 7
+          stale-issue-message: "Dieses Issue ist seit 30 Tagen inaktiv. Bitte aktualisieren, sonst wird es in 7 Tagen geschlossen."
+          close-issue-message: "Dieses Issue wurde wegen Inaktivität geschlossen."
+          stale-pr-message: "Dieser PR ist seit 30 Tagen inaktiv. Bitte aktualisieren, sonst wird er in 7 Tagen geschlossen."
+          close-pr-message: "Dieser PR wurde wegen Inaktivität geschlossen."
+          exempt-issue-labels: "pinned,security,blocked"
+          exempt-pr-labels: "pinned,security,blocked"


### PR DESCRIPTION
Added GitHub Actions stale workflow.
Marks issues and pull requests as stale after 30 days and closes them after 7 days.
Runs nightly and can be triggered manually.